### PR TITLE
Analyze directory tree and archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Complete!
 * exception `elfdeps.ELFError`
 * dataclass `elfdeps.ELFInfo`
 * dataclass `elfdeps.SOInfo`
+* `elfdeps.analyze_dirtree(dirname, settings=None) -> Generator[ELFInfo, None, None]`
 * `elfdeps.analyze_elffile(elffile, *, filename, is_exec, settings=None) -> ELFInfo`
 * `elfdeps.analyze_file(filename, *, settings=None) -> ELFInfo`
+* `elfdeps.analyze_tarfile(tfile, *, settings=None) -> Generator[ELFInfo, None, None]`
 * `elfdeps.analyze_tarmember(tfile, tarinfo, *, settings=None) -> ELFInfo`
+* `elfdeps.analyze_zipfile(zfile, *, settings=None) -> Generator[ELFInfo, None, None]`
 * `elfdeps.analyze_zipmember(zfile, zipinfo, *, settings=None) -> ELFInfo`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ source = [
    "src/elfdeps",
    ".tox/py*/**/site-packages/elfdeps",
 ]
-tests =[
+tests = [
    "tests/",
 ]
 

--- a/src/elfdeps/__init__.py
+++ b/src/elfdeps/__init__.py
@@ -5,16 +5,22 @@ __all__ = (
     "ELFError",
     "ELFInfo",
     "SOInfo",
+    "analyze_dirtree",
     "analyze_elffile",
     "analyze_file",
+    "analyze_tarfile",
     "analyze_tarmember",
+    "analyze_zipfile",
     "analyze_zipmember",
 )
 
 from elftools.common.exceptions import ELFError
 
 from ._archives import (
+    analyze_dirtree,
+    analyze_tarfile,
     analyze_tarmember,
+    analyze_zipfile,
     analyze_zipmember,
 )
 from ._elfdeps import (

--- a/src/elfdeps/_archives.py
+++ b/src/elfdeps/_archives.py
@@ -1,15 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
 """Analyze archive members"""
 
+import logging
+import os
 import pathlib
 import stat
 import tarfile
 import typing
 import zipfile
 
+from elftools.common.exceptions import ELFError
 from elftools.elf.elffile import ELFFile
 
 from ._elfdeps import ELFAnalyzeSettings, ELFInfo, analyze_elffile
+from ._fileinfo import is_executable_file
+
+logger = logging.getLogger(__name__)
+
+
+def _zipinfo_mode(zipinfo: zipfile.ZipInfo) -> int:
+    """Full mode for zipinfo object"""
+    # mode may not contain reg file info
+    mode = zipinfo.external_attr >> 16
+    if stat.S_IFMT(mode) == 0:
+        lo = zipinfo.external_attr & 0xFFFF
+        if lo & 0x10:
+            # MS-DOS directory
+            mode |= stat.S_IFDIR
+        else:
+            mode |= stat.S_IFREG
+    return mode
 
 
 def analyze_zipmember(
@@ -19,14 +39,50 @@ def analyze_zipmember(
     settings: ELFAnalyzeSettings | None = None,
 ) -> ELFInfo:
     """Analyze a zipfile member"""
-    mode = zipinfo.external_attr >> 16
-    is_exec = bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+    mode = _zipinfo_mode(zipinfo)
+    is_exec = is_executable_file(mode)
     filename = pathlib.Path(zipinfo.filename)
     with zfile.open(zipinfo, mode="r") as f:
         elffile = ELFFile(f)
         return analyze_elffile(
             elffile, filename=filename, is_exec=is_exec, settings=settings
         )
+
+
+def analyze_zipfile(
+    zfile: zipfile.ZipFile, *, settings: ELFAnalyzeSettings | None = None
+) -> typing.Generator[ELFInfo, None, None]:
+    """Analyze a zip file"""
+    if settings is None:
+        settings = ELFAnalyzeSettings()
+    for zipinfo in zfile.infolist():
+        filename = pathlib.Path(zipinfo.filename)
+        mode = _zipinfo_mode(zipinfo)
+        if settings.is_candidate(filename, mode):
+            try:
+                yield analyze_zipmember(zfile, zipinfo, settings=settings)
+            except ELFError as err:
+                # not an ELF file (e.g. a script or linker script)
+                logger.debug("%s is not a ELF file: %s", filename, err)
+
+
+def _tarinfo_mode(tarinfo: tarfile.TarInfo) -> int:
+    """Full mode for tarinfo"""
+    # tarinfo.mode contains only permission bits
+    mode = tarinfo.mode
+    if tarinfo.isreg():
+        mode |= stat.S_IFREG
+    elif tarinfo.isdir():
+        mode |= stat.S_IFDIR
+    elif tarinfo.issym():
+        mode |= stat.S_IFLNK
+    elif tarinfo.isblk():
+        mode |= stat.S_IFBLK
+    elif tarinfo.ischr():
+        mode |= stat.S_IFCHR
+    elif tarinfo.isfifo():
+        mode |= stat.S_IFIFO
+    return mode
 
 
 def analyze_tarmember(
@@ -36,8 +92,8 @@ def analyze_tarmember(
     settings: ELFAnalyzeSettings | None = None,
 ) -> ELFInfo:
     """Analze a tarfile member"""
-    mode = tarinfo.mode
-    is_exec = bool(mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+    mode = _tarinfo_mode(tarinfo)
+    is_exec = is_executable_file(mode)
     filename = pathlib.Path(tarinfo.name)
     f = tfile.extractfile(tarinfo)
     if typing.TYPE_CHECKING:
@@ -47,3 +103,82 @@ def analyze_tarmember(
         return analyze_elffile(
             elffile, filename=filename, is_exec=is_exec, settings=settings
         )
+
+
+def analyze_tarfile(
+    tfile: tarfile.TarFile, *, settings: ELFAnalyzeSettings | None = None
+) -> typing.Generator[ELFInfo, None, None]:
+    """Analyze a tar ball"""
+    if settings is None:
+        settings = ELFAnalyzeSettings()
+    for tarinfo in tfile:
+        filename = pathlib.Path(tarinfo.name)
+        mode = _tarinfo_mode(tarinfo)
+        if settings.is_candidate(filename, mode):
+            try:
+                yield analyze_tarmember(tfile, tarinfo, settings=settings)
+            except ELFError as err:
+                # not an ELF file (e.g. a script or linker script)
+                logger.debug("%s is not a ELF file: %s", filename, err)
+
+
+OnError = typing.Callable[[pathlib.Path, OSError | ELFError], None] | None
+
+
+def _scanwalk(
+    dirname: pathlib.Path, onerror: OnError = None
+) -> typing.Generator[os.DirEntry, None, None]:
+    """Recursive scandir"""
+    try:
+        it = os.scandir(dirname)
+    except OSError as err:
+        if onerror is not None:
+            onerror(dirname, err)
+        return
+
+    with it:
+        while True:
+            try:
+                entry = next(it)
+            except StopIteration:
+                break
+            except OSError as err:
+                if onerror is not None:
+                    onerror(dirname, err)
+                return
+            try:
+                is_dir = entry.is_dir(follow_symlinks=False)
+            except OSError:
+                is_dir = False
+            if is_dir:
+                yield from _scanwalk(pathlib.Path(entry.path), onerror=onerror)
+            else:
+                yield entry
+
+
+def analyze_dirtree(
+    dirname: pathlib.Path,
+    *,
+    settings: ELFAnalyzeSettings | None = None,
+    onerror: OnError = None,
+) -> typing.Generator[ELFInfo, None, None]:
+    """Recursively analyze dirctory tree"""
+    if settings is None:
+        settings = ELFAnalyzeSettings()
+    for entry in _scanwalk(dirname):
+        filename = pathlib.Path(entry.path)
+        try:
+            mode = entry.stat(follow_symlinks=False).st_mode
+            if settings.is_candidate(filename, mode):
+                with filename.open("rb") as f:
+                    elffile = ELFFile(f)
+                    yield analyze_elffile(
+                        elffile,
+                        filename=filename,
+                        is_exec=is_executable_file(mode),
+                        settings=settings,
+                    )
+        except (OSError, ELFError) as err:
+            logger.debug("%s is not a ELF file or is not accessible: %s", filename, err)
+            if onerror is not None:
+                onerror(filename, err)

--- a/src/elfdeps/_fileinfo.py
+++ b/src/elfdeps/_fileinfo.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""File prefix and suffix"""
+
+import importlib.machinery
+import pathlib
+import re
+import stat
+
+# platlib extension suffixes
+EXTENSION_SUFFIXES = tuple(importlib.machinery.EXTENSION_SUFFIXES)
+# Python-only suffix
+PYTHON_EXTENSION_SUFFIXES = tuple(es for es in EXTENSION_SUFFIXES if es != ".so")
+# dynamic linker prefix
+LD_PREFIX: tuple[str, ...] = ("ld.", "ld-", "ld64.", "ld64-")
+# pattern for libname.so / libname.so.1.2.3
+LIB_RE = re.compile(
+    r"^"
+    # library or dynamic linker prefix
+    r"(?P<prefix>lib|ld(?:64)?[.-])"
+    # name starts with an alphanumic character
+    r"(?P<name>\w.*)"
+    r"\.so"
+    # optional SOVERSION
+    r"(?:\.(?P<version>[\d.]+))?"
+    r"$"
+)
+
+
+def is_so_candidate(filename: pathlib.Path) -> bool:
+    """Does the filename look like a a shared object?
+
+    - Python shared extension with EXTENSION_SUFFIX, e.g.
+      `name.cpython-312-x86_64-linux-gnu.so`, `name.abi3.so`, or
+      `name.so`
+    - unversioned shared library, e.g. `libfoo.so`
+    - versioned shared library, e.g. `libfoo.so.1.2.3`
+    - dynamic linker, e.g. `ld-linux-x86-64.so.2`
+    """
+    name: str = filename.name
+    if name.endswith(EXTENSION_SUFFIXES):
+        # Python extension
+        return True
+    # lib*.so, lib*.so.1.2.3, dynamic linker
+    mo = LIB_RE.match(name)
+    return mo is not None
+
+
+_ix = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+
+
+def is_executable_file(mode: int) -> bool:
+    """Is mode for an executable file (no symlink)?"""
+    if not stat.S_ISREG(mode):
+        return False
+    return bool(stat.S_IMODE(mode) & _ix)

--- a/tests/test_elfdeps.py
+++ b/tests/test_elfdeps.py
@@ -26,6 +26,12 @@ def test_zipmember_python(tmp_path: pathlib.Path):
         assert info.requires == orig_info.requires
         assert info.provides == orig_info.provides
 
+        infos = list(elfdeps.analyze_zipfile(zf))
+        assert len(infos) == 1
+        info = infos[0]
+        assert info.requires == orig_info.requires
+        assert info.provides == orig_info.provides
+
 
 def test_tarmember_python(tmp_path: pathlib.Path):
     orig_info = elfdeps.analyze_file(pathlib.Path(sys.executable))
@@ -37,6 +43,12 @@ def test_tarmember_python(tmp_path: pathlib.Path):
     with tarfile.TarFile.open(tname, mode="r:gz") as tf:
         tarinfo = tf.getmember("python")
         info = elfdeps.analyze_tarmember(tf, tarinfo)
+        assert info.requires == orig_info.requires
+        assert info.provides == orig_info.provides
+
+        infos = list(elfdeps.analyze_tarfile(tf))
+        assert len(infos) == 1
+        info = infos[0]
         assert info.requires == orig_info.requires
         assert info.provides == orig_info.provides
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,22 +1,26 @@
 import pathlib
+import shutil
 import subprocess
 import sys
 import tarfile
 import zipfile
 
 
-def test_main_binary() -> None:
-    python = pathlib.Path(sys.executable).resolve()
+def test_main_binary(tmp_path: pathlib.Path) -> None:
+    python = tmp_path / "python"
+    shutil.copy2(sys.executable, python)
     out = subprocess.check_output(["elfdeps", python], text=True)
+    assert str(python) in out
+    out = subprocess.check_output(["elfdeps", str(tmp_path)], text=True)
     assert str(python) in out
 
 
-def test_main_tarfile(tmp_path: pathlib.Path):
+def test_main_tarfile(tmp_path: pathlib.Path) -> None:
     tname = tmp_path / "test.tar.gz"
     python = pathlib.Path(sys.executable).resolve()
     with tarfile.TarFile.open(tname, mode="w:gz") as tf:
         # FIXME: remove '.so' suffix
-        tf.add(python, "python-binary.so")
+        tf.add(python, "python-binary")
         tf.add(__file__, "test.py")
     out = subprocess.check_output(["elfdeps", str(tname)], text=True)
     assert "python-binary" in out
@@ -26,8 +30,7 @@ def test_main_zipfile(tmp_path: pathlib.Path) -> None:
     zname = tmp_path / "test.zip"
     python = pathlib.Path(sys.executable).resolve()
     with zipfile.ZipFile(zname, mode="w") as zf:
-        # FIXME: remove '.so' suffix
-        zf.write(python, "python-binary.so")
+        zf.write(python, "python-binary")
         zf.write(__file__, "test.py")
     out = subprocess.check_output(["elfdeps", str(zname)], text=True)
     assert "python-binary" in out


### PR DESCRIPTION
Add APIs to analyze a directory tree or an archive (zip, tar). By default, all regular files with executable bit are analyzed except for files that have a `.py`, `.sh`, or docs extension (md, rst, txt). In addition, files with a pattern like `lib*.so`, `lib*.so.1.2.3`, and `ld-*.so` are analyzed, too.