### PR TITLE
fix: optimize archive access

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,7 @@ jobs:
         with:
           name: coverage-${{ matrix.python }}
           path: .coverage.*
+          include-hidden-files: true
           if-no-files-found: ignore
 
   ruff:

--- a/src/elfdeps/_archives.py
+++ b/src/elfdeps/_archives.py
@@ -4,8 +4,10 @@
 import logging
 import os
 import pathlib
+import shutil
 import stat
 import tarfile
+import tempfile
 import typing
 import zipfile
 
@@ -16,6 +18,32 @@ from ._elfdeps import ELFAnalyzeSettings, ELFInfo, analyze_elffile
 from ._fileinfo import is_executable_file
 
 logger = logging.getLogger(__name__)
+
+# Switch from memory IO to temporary file after 2 MB. The size
+# covers trivial extension. Larger files are written to a temp file.
+_MAX_SPOOL_SIZE = 2 * 1024 * 1024
+
+
+def _spooled_analyze_elffile(
+    f: typing.IO[bytes],
+    filename: pathlib.Path,
+    is_exec: bool,
+    settings: ELFAnalyzeSettings | None = None,
+) -> ELFInfo:
+    """Analyze elffile with spooled temporary file
+
+    elftools performs a lot of small read and seek operations. Seeking
+    in zip and tar files is slow. Use memory IO for small files and
+    temporary file for large files.
+    """
+    with tempfile.SpooledTemporaryFile(max_size=_MAX_SPOOL_SIZE) as t:
+        # copy blocks of _MAX_SPOOL_SIZE
+        shutil.copyfileobj(f, t, length=_MAX_SPOOL_SIZE)
+        t.seek(0)
+        elffile = ELFFile(t)
+        return analyze_elffile(
+            elffile, filename=filename, is_exec=is_exec, settings=settings
+        )
 
 
 def _zipinfo_mode(zipinfo: zipfile.ZipInfo) -> int:
@@ -43,9 +71,8 @@ def analyze_zipmember(
     is_exec = is_executable_file(mode)
     filename = pathlib.Path(zipinfo.filename)
     with zfile.open(zipinfo, mode="r") as f:
-        elffile = ELFFile(f)
-        return analyze_elffile(
-            elffile, filename=filename, is_exec=is_exec, settings=settings
+        return _spooled_analyze_elffile(
+            f, filename=filename, is_exec=is_exec, settings=settings
         )
 
 
@@ -99,9 +126,8 @@ def analyze_tarmember(
     if typing.TYPE_CHECKING:
         assert f is not None
     with f:
-        elffile = ELFFile(f)
-        return analyze_elffile(
-            elffile, filename=filename, is_exec=is_exec, settings=settings
+        return _spooled_analyze_elffile(
+            f, filename=filename, is_exec=is_exec, settings=settings
         )
 
 


### PR DESCRIPTION
Fix performance issues in `analyze_zipmember` and `analyze_tarmember` functions. The elftools `ELFFile` class performance a lot of seek and small read operations. Seeking in a zipfile and tarfile is slow.

The old implementation takes about 1.56s to analyze Pillow's 12.2.0 wheel for x86_64. The new code takes 0.22s. The performance difference is even more dramatic with Torch. With the new code, it takes less than 2 seconds to analyze a Torch 2.10.0+cpu wheel. The old code never finished in a reasonable amount of time.