### PR TITLE
ci: harden GitHub Actions workflows, add AGENTS.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,16 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -24,12 +29,13 @@ jobs:
           - "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -46,7 +52,7 @@ jobs:
         run: tox
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-${{ matrix.python }}
           path: .coverage.*
@@ -64,12 +70,13 @@ jobs:
           - "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -91,12 +98,13 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.14"
           cache: pip
@@ -105,7 +113,7 @@ jobs:
             **/tox.ini
 
       - name: Download coverage data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: coverage-*
           merge-multiple: true
@@ -123,7 +131,7 @@ jobs:
           coverage report --fail-under=70
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           path: htmlcov
           name: htmlcov

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly on Sundays
+    - cron: "0 3 * * 0"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -16,24 +16,31 @@ on:
         types:
             - published
 
-permissions:
-    contents: read
+permissions: {}
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
     build-package:
         name: Build and check packages
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+              with:
+                  persist-credentials: false
 
-            - uses: hynek/build-and-inspect-python-package@v2
+            - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
 
     # push to Test PyPI on
     # - a new GitHub release is published
     # - a PR is merged into main branch
     publish-test-pypi:
         name: Publish packages to test.pypi.org
-        # environment: publish-test-pypi
+        environment: pypi
         if: |
             github.repository_owner == 'python-wheel-build' && (
                 github.event.action == 'published' ||
@@ -48,13 +55,13 @@ jobs:
 
         steps:
             - name: Fetch build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
               with:
                   name: Packages
                   path: dist
 
             - name: Upload to Test PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
               with:
                   repository-url: https://test.pypi.org/legacy/
 
@@ -62,7 +69,7 @@ jobs:
     # - a new GitHub release is published
     publish-pypi:
         name: Publish release to pypi.org
-        # environment: publish-pypi
+        environment: pypi
         if: |
             github.repository_owner == 'python-wheel-build' && github.event.action == 'published'
         permissions:
@@ -76,12 +83,12 @@ jobs:
 
         steps:
             - name: Fetch build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
               with:
                   name: Packages
                   path: dist
 
-            - uses: sigstore/gh-action-sigstore-python@v2.1.1
+            - uses: sigstore/gh-action-sigstore-python@61f6a500bbfdd9a2a339cf033e5421951fbc1cd2  # v2.1.1
               with:
                   inputs: >-
                       ./dist/*.tar.gz
@@ -99,4 +106,4 @@ jobs:
               run: rm ./dist/*.sigstore
 
             - name: Upload to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+name: Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly on Saturdays
+    - cron: "30 1 * * 6"
+
+permissions: {}
+
+jobs:
+  analysis:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Claude Code
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# Agent instructions
+
+## Essential Rules
+
+### Do
+
+- Follow existing patterns — search codebase for similar code
+- Keep changes concise and focused
+- Run file-scoped commands for fast feedback
+- Chain exceptions: `raise ValueError(...) from err`
+
+### Don't
+
+- Don't run full test suite for small changes
+- Don't create temporary helper scripts or workarounds
+- Don't commit without running quality checks
+- Don't make large speculative changes — ask first
+- Don't use bare `except:` — always specify exception types
+
+## Commands
+
+### File-Scoped (prefer these)
+
+```sh
+tox -e py314 -- tests/test_<module>.py            # Test specific file
+tox -e py314 -- tests/test_<module>.py::test_name  # Test specific function
+```
+
+### Project-Wide
+
+```sh
+tox                # Full test suite
+tox -e lint        # Linting and type checking
+tox -e fix         # Auto-fix lint issues
+```
+
+## Safety and Permissions
+
+### Allowed Without Asking
+
+- Read files, search codebase
+- Run tests with tox
+- Edit existing files following established patterns
+
+### Ask First
+
+- Installing/updating packages in pyproject.toml
+- Git commit or push operations
+- Deleting files or entire modules
+- Creating new modules or major refactors
+
+## Project Structure
+
+- `src/elfdeps/` — Main package code
+- `tests/` — Unit tests
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Always use `git commit --signoff`.


### PR DESCRIPTION
## Summary

- Pin all actions to commit SHAs, add `persist-credentials: false` and concurrency groups
- Minimize permissions, add `environment: pypi` to publish jobs
- Add CodeQL, OpenSSF Scorecard, and Dependabot workflows
- Add AGENTS.md and `.claude/` to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)