### PR TITLE
fix: use enum.StrEnum instead of str, enum.Enum

### DIFF
--- a/src/elfdeps/_elfdeps.py
+++ b/src/elfdeps/_elfdeps.py
@@ -31,14 +31,14 @@ from ._fileinfo import (
 )
 
 
-class SymbolBinding(str, enum.Enum):
+class SymbolBinding(enum.StrEnum):
     """ELF dynamic symbol binding (STB_*)"""
 
     GLOBAL = "global"  # Global symbol
     WEAK = "weak"  # Weak symbol
 
 
-class SymbolType(str, enum.Enum):
+class SymbolType(enum.StrEnum):
     """ELF dynamic symbol type (STT_*)"""
 
     NOTYPE = "notype"  # Symbol type is unspecified


### PR DESCRIPTION
Fix ruff UP042 lint errors in SymbolBinding and SymbolType classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)