### PR TITLE
ci: remove Test PyPI publishing

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -35,36 +35,6 @@ jobs:
 
             - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
 
-    # push to Test PyPI on
-    # - a new GitHub release is published
-    # - a PR is merged into main branch
-    publish-test-pypi:
-        name: Publish packages to test.pypi.org
-        environment: pypi
-        if: |
-            github.repository_owner == 'python-wheel-build' && (
-                github.event.action == 'published' ||
-                (github.event_name == 'push' && github.ref == 'refs/heads/main')
-            )
-        permissions:
-            contents: read
-            # see https://docs.pypi.org/trusted-publishers/
-            id-token: write
-        runs-on: ubuntu-latest
-        needs: build-package
-
-        steps:
-            - name: Fetch build artifacts
-              uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-              with:
-                  name: Packages
-                  path: dist
-
-            - name: Upload to Test PyPI
-              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
-              with:
-                  repository-url: https://test.pypi.org/legacy/
-
     # push to Production PyPI on
     # - a new GitHub release is published
     publish-pypi:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,6 @@ exclude_lines = [
 ]
 
 [tool.setuptools_scm]
-# do not include +gREV local version, required for Test PyPI upload
-local_scheme = "no-local-version"
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
Test PyPI was initially introduced to verify the upload workflow.
Now that the workflow is proven, Test PyPI is no longer needed.

Remove the publish-test-pypi job and the local_scheme workaround
that was only needed for Test PyPI compatibility.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Christian Heimes <cheimes@redhat.com>
