### PR TITLE
build: replace setuptools with hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling>=1.25", "hatch-vcs>=0.4"]
+build-backend = "hatchling.build"
 
 [project]
 name = "elfdeps"
@@ -74,7 +74,8 @@ exclude_lines = [
     "if typing.TYPE_CHECKING",
 ]
 
-[tool.setuptools_scm]
+[tool.hatch.version]
+source = "vcs"
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
Our team standardizes on hatchling as a lightweight build backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)