### PR TITLE
ci: change Mergify merge method from merge to rebase

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -22,7 +22,7 @@ pull_request_rules:
 
     actions:
       merge:
-        method: merge
+        method: rebase
 
   - name: Ping author on conflicts
     conditions:


### PR DESCRIPTION
This commit changes mergify merge method to rebase.