### PR TITLE
ci: use PyPI attestations instead of sigstore + gh release upload

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -35,22 +35,16 @@ jobs:
 
             - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2.17.0
 
-    # push to Production PyPI on
-    # - a new GitHub release is published
     publish-pypi:
-        name: Publish release to pypi.org
-        environment: pypi
-        if: |
-            github.repository_owner == 'python-wheel-build' && github.event.action == 'published'
-        permissions:
-            # see https://docs.pypi.org/trusted-publishers/
-            id-token: write
-            # allow gh release upload
-            contents: write
-
-        runs-on: ubuntu-latest
+        name: Publish to PyPI
+        if: github.repository_owner == 'python-wheel-build' && github.event.action == 'published'
         needs: build-package
-
+        runs-on: ubuntu-latest
+        environment: pypi
+        permissions:
+            id-token: write
+            attestations: write
+            contents: read
         steps:
             - name: Fetch build artifacts
               uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -58,22 +52,12 @@ jobs:
                   name: Packages
                   path: dist
 
-            - uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc  # v3.3.0
-              with:
-                  inputs: >-
-                      ./dist/*.tar.gz
-                      ./dist/*.whl
-
-            - name: Upload artifacts and signatures to GitHub release
-              env:
-                  GITHUB_TOKEN: ${{ github.token }}
-              run: >-
-                  gh release upload '${{ github.ref_name }}' dist/* --repo '${{ github.repository }}'
-
-            # PyPI does not accept .sigstore artifacts and
-            # gh-action-pypi-publish has no option to ignore them.
-            - name: Remove sigstore signatures before uploading to PyPI
-              run: rm ./dist/*.sigstore
+            - name: Verify sdist and wheel are present
+              run: |
+                  ls dist/*.tar.gz
+                  ls dist/*.whl
 
             - name: Upload to PyPI
               uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+              with:
+                  attestations: true


### PR DESCRIPTION
Replace sigstore signing and gh release upload with PyPI publish
attestations. Fixes release upload failure for v0.3.0.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Christian Heimes <cheimes@redhat.com>
